### PR TITLE
Implement Chatwoot OpenAI webhook handler

### DIFF
--- a/app/controllers/chatwoot/openai_handler_controller.rb
+++ b/app/controllers/chatwoot/openai_handler_controller.rb
@@ -1,0 +1,6 @@
+class Chatwoot::OpenaiHandlerController < ActionController::API
+  def create
+    Chatwoot::OpenaiHandlerJob.perform_later(params.to_unsafe_h)
+    head :ok
+  end
+end

--- a/app/jobs/chatwoot/openai_handler_job.rb
+++ b/app/jobs/chatwoot/openai_handler_job.rb
@@ -1,0 +1,7 @@
+class Chatwoot::OpenaiHandlerJob < ApplicationJob
+  queue_as :default
+
+  def perform(payload = {})
+    Chatwoot::OpenaiHandlerService.new(payload).perform
+  end
+end

--- a/app/services/chatwoot/openai_handler_service.rb
+++ b/app/services/chatwoot/openai_handler_service.rb
@@ -1,0 +1,68 @@
+class Chatwoot::OpenaiHandlerService
+  def initialize(payload)
+    @payload = payload.deep_symbolize_keys
+    @client = OpenAI::Client.new(access_token: ENV.fetch('OPENAI_API_KEY'))
+  end
+
+  def perform
+    return unless ai_enabled?
+
+    doc_url = custom_attrs[:google_doc_url]
+    doc_text = GoogleDocs.extract_text_from_public_doc(doc_url)
+    sections = GoogleDocs.parse_sections(doc_text)
+    system_prompt = sections[:system_prompt]
+    faq = sections[:faq]
+    prompt = system_prompt.to_s
+    prompt += "\n\nFAQ:\n#{faq}" if faq.present?
+    reply = generate_reply(prompt, message_content)
+    send_reply(reply) if reply.present?
+  rescue StandardError => e
+    Rails.logger.error("[OpenaiHandlerService] #{e.message}")
+  end
+
+  private
+
+  def ai_enabled?
+    @payload[:message_type] == 'incoming' &&
+      @payload.dig(:sender, :type) == 'contact' &&
+      custom_attrs[:ai_enabled] == true
+  end
+
+  def custom_attrs
+    @payload.dig(:conversation, :custom_attributes) || {}
+  end
+
+  def message_content
+    @payload[:content].to_s
+  end
+
+  def generate_reply(prompt, user_message)
+    params = {
+      model: ENV.fetch('OPENAI_GPT_MODEL', 'gpt-4o-mini'),
+      messages: [
+        { role: 'system', content: prompt },
+        { role: 'user', content: user_message }
+      ]
+    }
+    response = @client.chat(parameters: params)
+    response.dig('choices', 0, 'message', 'content')
+  rescue OpenAI::Error => e
+    Rails.logger.error("[OpenaiHandlerService] OpenAI API Error: #{e.message}")
+    nil
+  end
+
+  def send_reply(text)
+    account_id = @payload.dig(:account, :id) || @payload[:account_id] ||
+                 @payload.dig(:conversation, :account_id)
+    conversation_id = @payload.dig(:conversation, :id)
+    return unless account_id && conversation_id
+
+    url = "https://#{ENV.fetch('CHATWOOT_HOST')}/api/v1/accounts/#{account_id}/conversations/#{conversation_id}/messages"
+    headers = {
+      'Content-Type' => 'application/json',
+      'api_access_token' => ENV.fetch('CHATWOOT_API_KEY')
+    }
+    body = { content: text, message_type: 'outgoing' }.to_json
+    HTTParty.post(url, headers: headers, body: body)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -490,6 +490,7 @@ Rails.application.routes.draw do
   post 'webhooks/whatsapp/:phone_number', to: 'webhooks/whatsapp#process_payload'
   get 'webhooks/instagram', to: 'webhooks/instagram#verify'
   post 'webhooks/instagram', to: 'webhooks/instagram#events'
+  post 'chatwoot/openai_handler', to: 'chatwoot/openai_handler#create'
 
   namespace :twitter do
     resource :callback, only: [:show]

--- a/google_docs.rb
+++ b/google_docs.rb
@@ -23,4 +23,26 @@ module GoogleDocs
     warn "[Google Docs] Error: #{e.message}"
     raise "Document fetch error: #{e.message}"
   end
+
+  def parse_sections(text)
+    sections = {}
+    current = nil
+    buffer = []
+    text.each_line do |line|
+      case line.strip
+      when /^#\s*SYSTEM_PROMPT/i
+        sections[current] = buffer.join("\n").strip if current
+        current = :system_prompt
+        buffer = []
+      when /^#\s*FAQ/i
+        sections[current] = buffer.join("\n").strip if current
+        current = :faq
+        buffer = []
+      else
+        buffer << line if current
+      end
+    end
+    sections[current] = buffer.join("\n").strip if current
+    { system_prompt: sections[:system_prompt], faq: sections[:faq] }
+  end
 end


### PR DESCRIPTION
## Summary
- parse Google Docs sections for FAQ/system prompt
- create Chatwoot OpenAI handler service, job and controller
- expose `/chatwoot/openai_handler` route

## Testing
- `bundle exec rubocop -a`
- `bundle exec rspec spec/lib/integrations/openai/processor_service_spec.rb` *(fails: connection to server at "::1" port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a0187cfd8832dae7d1eed534151c4