### PR TITLE
Add log for conversation open

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -281,7 +281,10 @@ class Conversation < ApplicationRecord
       CONVERSATION_READ => -> { saved_change_to_contact_last_seen_at? },
       CONVERSATION_CONTACT_CHANGED => -> { saved_change_to_contact_id? }
     }.each do |event, condition|
-      condition.call && dispatcher_dispatch(event, status_change)
+      next unless condition.call
+
+      Rails.logger.info("Conversation #{id} opened") if event == CONVERSATION_OPENED
+      dispatcher_dispatch(event, status_change)
     end
   end
 


### PR DESCRIPTION
## Summary
- log an info message whenever a conversation status changes to open

## Testing
- `bundle exec rspec spec/models/conversation_spec.rb` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_688b80f25930832d8d0a7f151861206f