### PR TITLE
feat: remove captain premium gating

### DIFF
--- a/app/javascript/dashboard/components-next/Conversation/SidepanelSwitch.vue
+++ b/app/javascript/dashboard/components-next/Conversation/SidepanelSwitch.vue
@@ -2,20 +2,11 @@
 import Button from 'dashboard/components-next/button/Button.vue';
 import { useUISettings } from 'dashboard/composables/useUISettings';
 import { computed } from 'vue';
-import { FEATURE_FLAGS } from 'dashboard/featureFlags';
-import { useMapGetter } from 'dashboard/composables/store';
 import { useKeyboardEvents } from 'dashboard/composables/useKeyboardEvents';
 
 const { updateUISettings } = useUISettings();
 
-const currentAccountId = useMapGetter('getCurrentAccountId');
-const isFeatureEnabledonAccount = useMapGetter(
-  'accounts/isFeatureEnabledonAccount'
-);
-
-const showCopilotTab = computed(() =>
-  isFeatureEnabledonAccount.value(currentAccountId.value, FEATURE_FLAGS.CAPTAIN)
-);
+const showCopilotTab = computed(() => true);
 
 const { uiSettings } = useUISettings();
 const isContactSidebarOpen = computed(

--- a/app/javascript/dashboard/components-next/copilot/CopilotLauncher.vue
+++ b/app/javascript/dashboard/components-next/copilot/CopilotLauncher.vue
@@ -3,8 +3,6 @@ import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import Button from 'dashboard/components-next/button/Button.vue';
 import { useUISettings } from 'dashboard/composables/useUISettings';
-import { useMapGetter } from 'dashboard/composables/store';
-import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 const route = useRoute();
 
 const { uiSettings, updateUISettings } = useUISettings();
@@ -24,21 +22,8 @@ const isConversationRoute = computed(() => {
   return CONVERSATION_ROUTES.includes(route.name);
 });
 
-const currentAccountId = useMapGetter('getCurrentAccountId');
-const isFeatureEnabledonAccount = useMapGetter(
-  'accounts/isFeatureEnabledonAccount'
-);
-
 const showCopilotLauncher = computed(() => {
-  const isCaptainEnabled = isFeatureEnabledonAccount.value(
-    currentAccountId.value,
-    FEATURE_FLAGS.CAPTAIN
-  );
-  return (
-    isCaptainEnabled &&
-    !uiSettings.value.is_copilot_panel_open &&
-    !isConversationRoute.value
-  );
+  return !uiSettings.value.is_copilot_panel_open && !isConversationRoute.value;
 });
 const toggleSidebar = () => {
   updateUISettings({

--- a/app/javascript/dashboard/components/copilot/CopilotContainer.vue
+++ b/app/javascript/dashboard/components/copilot/CopilotContainer.vue
@@ -4,7 +4,6 @@ import { useStore } from 'dashboard/composables/store';
 import Copilot from 'dashboard/components-next/copilot/Copilot.vue';
 import { useMapGetter } from 'dashboard/composables/store';
 import { useUISettings } from 'dashboard/composables/useUISettings';
-import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 defineProps({
   conversationInboxType: {
     type: String,
@@ -25,12 +24,6 @@ const messages = computed(() =>
     selectedCopilotThreadId.value
   )
 );
-
-const currentAccountId = useMapGetter('getCurrentAccountId');
-const isFeatureEnabledonAccount = useMapGetter(
-  'accounts/isFeatureEnabledonAccount'
-);
-
 const selectedAssistantId = ref(null);
 const { uiSettings, updateUISettings } = useUISettings();
 
@@ -63,12 +56,8 @@ const setAssistant = async assistant => {
 };
 
 const shouldShowCopilotPanel = computed(() => {
-  const isCaptainEnabled = isFeatureEnabledonAccount.value(
-    currentAccountId.value,
-    FEATURE_FLAGS.CAPTAIN
-  );
   const { is_copilot_panel_open: isCopilotPanelOpen } = uiSettings.value;
-  return isCaptainEnabled && isCopilotPanelOpen && !uiFlags.value.fetchingList;
+  return isCopilotPanelOpen && !uiFlags.value.fetchingList;
 });
 
 const handleReset = () => {

--- a/app/javascript/dashboard/composables/useCaptain.js
+++ b/app/javascript/dashboard/composables/useCaptain.js
@@ -2,14 +2,13 @@ import { computed } from 'vue';
 import { useStore } from 'dashboard/composables/store.js';
 import { useAccount } from 'dashboard/composables/useAccount';
 import { useCamelCase } from 'dashboard/composables/useTransformKeys';
-import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 
 export function useCaptain() {
   const store = useStore();
-  const { isCloudFeatureEnabled, currentAccount } = useAccount();
+  const { currentAccount } = useAccount();
 
   const captainEnabled = computed(() => {
-    return isCloudFeatureEnabled(FEATURE_FLAGS.CAPTAIN);
+    return true;
   });
 
   const captainLimits = computed(() => {

--- a/app/javascript/dashboard/featureFlags.js
+++ b/app/javascript/dashboard/featureFlags.js
@@ -31,7 +31,6 @@ export const FEATURE_FLAGS = {
   INBOUND_EMAILS: 'inbound_emails',
   IP_LOOKUP: 'ip_lookup',
   LINEAR: 'linear_integration',
-  CAPTAIN: 'captain_integration',
   CUSTOM_ROLES: 'custom_roles',
   CHATWOOT_V4: 'chatwoot_v4',
   REPORT_V4: 'report_v4',

--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -72,10 +72,7 @@ export default {
       );
     },
     showAudioTranscriptionConfig() {
-      return this.isFeatureEnabledonAccount(
-        this.accountId,
-        FEATURE_FLAGS.CAPTAIN
-      );
+      return true;
     },
     languagesSortedByCode() {
       const enabledLanguages = [...this.enabledLanguages];

--- a/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
+++ b/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
@@ -14,7 +14,6 @@ class Enterprise::Billing::HandleStripeEventService
     channel_facebook
     channel_email
     channel_instagram
-    captain_integration
   ].freeze
 
   # Additional features available starting with the Business plan

--- a/enterprise/app/services/messages/audio_transcription_service.rb
+++ b/enterprise/app/services/messages/audio_transcription_service.rb
@@ -20,7 +20,6 @@ class Messages::AudioTranscriptionService < Llm::BaseOpenAiService
   private
 
   def can_transcribe?
-    return false unless account.feature_enabled?('captain_integration')
     return false if account.audio_transcriptions.blank?
 
     account.usage_limits[:captain][:responses][:current_available].positive?

--- a/enterprise/config/premium_features.yml
+++ b/enterprise/config/premium_features.yml
@@ -3,5 +3,4 @@
 - audit_logs
 - response_bot
 - sla
-- captain_integration
 - custom_roles

--- a/spec/enterprise/services/internal/reconcile_plan_config_service_spec.rb
+++ b/spec/enterprise/services/internal/reconcile_plan_config_service_spec.rb
@@ -11,15 +11,12 @@ RSpec.describe Internal::ReconcilePlanConfigService do
 
       it 'disables the premium features for accounts' do
         account = create(:account)
-        account.enable_features!('disable_branding', 'audit_logs', 'captain_integration')
-        account_with_captain = create(:account)
-        account_with_captain.enable_features!('captain_integration')
-        disable_branding_account = create(:account)
-        disable_branding_account.enable_features!('disable_branding')
+        account.enable_features!('disable_branding', 'audit_logs')
+        another_account = create(:account)
+        another_account.enable_features!('disable_branding')
         service.perform
-        expect(account.reload.enabled_features.keys).not_to include('captain_integration', 'disable_branding', 'audit_logs')
-        expect(account_with_captain.reload.enabled_features.keys).not_to include('captain_integration')
-        expect(disable_branding_account.reload.enabled_features.keys).not_to include('disable_branding')
+        expect(account.reload.enabled_features.keys).not_to include('disable_branding', 'audit_logs')
+        expect(another_account.reload.enabled_features.keys).not_to include('disable_branding')
       end
 
       it 'creates a premium config reset warning if config was modified' do
@@ -56,15 +53,12 @@ RSpec.describe Internal::ReconcilePlanConfigService do
 
       it 'does not disable the premium features for accounts' do
         account = create(:account)
-        account.enable_features!('disable_branding', 'audit_logs', 'captain_integration')
-        account_with_captain = create(:account)
-        account_with_captain.enable_features!('captain_integration')
-        disable_branding_account = create(:account)
-        disable_branding_account.enable_features!('disable_branding')
+        account.enable_features!('disable_branding', 'audit_logs')
+        another_account = create(:account)
+        another_account.enable_features!('disable_branding')
         service.perform
-        expect(account.reload.enabled_features.keys).to include('captain_integration', 'disable_branding', 'audit_logs')
-        expect(account_with_captain.reload.enabled_features.keys).to include('captain_integration')
-        expect(disable_branding_account.reload.enabled_features.keys).to include('disable_branding')
+        expect(account.reload.enabled_features.keys).to include('disable_branding', 'audit_logs')
+        expect(another_account.reload.enabled_features.keys).to include('disable_branding')
       end
 
       it 'does not update the LOGO config' do

--- a/spec/enterprise/services/messages/audio_transcription_service_spec.rb
+++ b/spec/enterprise/services/messages/audio_transcription_service_spec.rb
@@ -18,16 +18,6 @@ RSpec.describe Messages::AudioTranscriptionService, type: :service do
   describe '#perform' do
     let(:service) { described_class.new(attachment) }
 
-    context 'when captain_integration feature is not enabled' do
-      before do
-        account.disable_features!('captain_integration')
-      end
-
-      it 'returns transcription limit exceeded' do
-        expect(service.perform).to eq({ error: 'Transcription limit exceeded' })
-      end
-    end
-
     context 'when transcription is successful' do
       before do
         # Mock can_transcribe? to return true and transcribe_audio method


### PR DESCRIPTION
## Summary
- drop `captain_integration` from enterprise premium features
- stop checking Captain feature flag across backend and frontend

## Testing
- `pnpm eslint app/javascript/dashboard/composables/useCaptain.js app/javascript/dashboard/components/copilot/CopilotContainer.vue app/javascript/dashboard/components-next/copilot/CopilotLauncher.vue app/javascript/dashboard/components-next/Conversation/SidepanelSwitch.vue app/javascript/dashboard/routes/dashboard/settings/account/Index.vue app/javascript/dashboard/featureFlags.js`
- `bundle exec rubocop enterprise/app/services/messages/audio_transcription_service.rb enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb spec/enterprise/services/messages/audio_transcription_service_spec.rb spec/enterprise/services/internal/reconcile_plan_config_service_spec.rb`
- `bundle exec rspec spec/enterprise/services/messages/audio_transcription_service_spec.rb spec/enterprise/services/internal/reconcile_plan_config_service_spec.rb` *(fails: connection to server at "::1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688e0fff1e08832d82c03f6ce3dd04cb