### PR TITLE
Enable captain integration feature for existing accounts

### DIFF
--- a/db/migrate/20250722152517_enable_captain_integration_for_accounts.rb
+++ b/db/migrate/20250722152517_enable_captain_integration_for_accounts.rb
@@ -1,0 +1,7 @@
+class EnableCaptainIntegrationForAccounts < ActiveRecord::Migration[7.1]
+  def up
+    Account.find_each do |account|
+      account.enable_features!('captain_integration')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add migration to enable `captain_integration` for all accounts

## Testing
- `bundle exec rubocop db/migrate/20250722152517_enable_captain_integration_for_accounts.rb`
- `bundle exec rails db:migrate` *(fails: connection to server at "::1", port 5432 failed: Connection refused)*


------
https://chatgpt.com/codex/tasks/task_e_688e13825dd4832dbefce9bda81d2bdd