### PR TITLE
docs: document DISABLE_ENTERPRISE for community builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Deploying Chatwoot to Heroku is a breeze. It's as simple as clicking this button
 
 Follow this [link](https://www.chatwoot.com/docs/environment-variables) to understand setting the correct environment variables for the app to work with all the features. There might be breakages if you do not set the relevant environment variables.
 
+### Disabling enterprise features in community builds
+
+If you're running a community build that still includes the `enterprise/` directory, set the environment variable `DISABLE_ENTERPRISE=true`.
+This forces `IS_ENTERPRISE=false` so the dashboard renders community behavior by default.
+
 
 ### DigitalOcean 1-Click Kubernetes deployment
 


### PR DESCRIPTION
## Summary
- document DISABLE_ENTERPRISE env var to force community mode when enterprise folder exists

## Testing
- `pnpm eslint`
- `bundle exec rubocop README.md` *(fails: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_688e18acf014832db106976772dd2879