### PR TITLE
chore: use pnpm consistently

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,8 +17,8 @@ FileUtils.chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
-  # Install JavaScript dependencies
-  # system('bin/yarn')
+  puts "\n== Installing JavaScript dependencies =="
+  system! 'pnpm install'
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')

--- a/bin/update
+++ b/bin/update
@@ -17,8 +17,8 @@ chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
-  # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  puts "\n== Installing JavaScript dependencies =="
+  system! 'pnpm install'
 
   puts "\n== Updating database =="
   system! 'POSTGRES_STATEMENT_TIMEOUT=600s bin/rails db:migrate'

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,9 +1,0 @@
-#!/usr/bin/env ruby
-APP_ROOT = File.expand_path('..', __dir__)
-Dir.chdir(APP_ROOT) do
-  exec 'yarnpkg', *ARGV
-rescue Errno::ENOENT
-  warn 'Yarn executable was not detected in the system.'
-  warn 'Download Yarn at https://yarnpkg.com/en/docs/install'
-  exit 1
-end

--- a/deployment/setup_18.04.sh
+++ b/deployment/setup_18.04.sh
@@ -7,17 +7,17 @@
 apt update && apt upgrade -y
 apt install -y curl
 curl -sL https://deb.nodesource.com/setup_12.x | bash -
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 apt update
 
 apt install -y \
-	git software-properties-common imagemagick libpq-dev \
+        git software-properties-common imagemagick libpq-dev \
     libxml2-dev libxslt1-dev file g++ gcc autoconf build-essential \
     libssl-dev libyaml-dev libreadline-dev gnupg2 nginx redis-server \
     redis-tools postgresql postgresql-contrib certbot \
-    python-certbot-nginx nodejs yarn patch ruby-dev zlib1g-dev liblzma-dev \
+    python-certbot-nginx nodejs patch ruby-dev zlib1g-dev liblzma-dev \
     libgmp-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev sudo
+
+npm install -g pnpm
 
 adduser --disabled-login --gecos "" chatwoot
 
@@ -54,7 +54,7 @@ else
   git checkout $1;
 fi
 bundle
-yarn
+pnpm install --frozen-lockfile
 
 cp .env.example .env
 sed -i -e "/SECRET_KEY_BASE/ s/=.*/=$secret/" .env


### PR DESCRIPTION
## Summary
- remove obsolete Yarn script
- install JS deps with pnpm in setup and update scripts
- drop Yarn from Ubuntu 18.04 install script and install pnpm instead

## Testing
- `bundle install`
- `pnpm install`
- `bundle exec rubocop -a`
- `pnpm test` *(fails: various missing keys / not implemented messages)*
- `bundle exec rspec` *(fails: connection to server at "::1", port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688e228788f8832da9872f2f484f8cc9