### PR TITLE
chore: add yaml linting workflow

### DIFF
--- a/.github/workflows/run_foss_spec.yml
+++ b/.github/workflows/run_foss_spec.yml
@@ -53,6 +53,15 @@ jobs:
       - name: Install pnpm dependencies
         run: pnpm i
 
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Run Rubocop
+        run: bundle exec rubocop
+
+      - name: Lint YAML
+        run: yamllint .github/workflows/run_foss_spec.yml
+
       - name: Strip enterprise code
         run: |
           rm -rf enterprise

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -219,6 +219,8 @@ AllCops:
     - 'tmp/**/*'
     - 'storage/**/*'
     - 'db/migrate/20230426130150_init_schema.rb'
+    - '**/*.yml'
+    - '**/*.yaml'
 
 FactoryBot/SyntaxMethods:
   Enabled: false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable
+


### PR DESCRIPTION
## Summary
- exclude YAML files from RuboCop analysis
- lint YAML files using yamllint in CI

## Testing
- `bundle exec rubocop`
- `yamllint .github/workflows/run_foss_spec.yml`


------
https://chatgpt.com/codex/tasks/task_e_688e2951f2f4832db514d222f7be895e