### PR TITLE
Remove premium flag for Captain integration feature

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -139,7 +139,6 @@
 - name: captain_integration
   display_name: Captain
   enabled: true
-  premium: false
 - name: custom_roles
   display_name: Custom Roles
   enabled: false


### PR DESCRIPTION
## Summary
- remove `premium: false` from Captain integration feature flag to align with convention for free features

## Testing
- `bundle exec rubocop`


------
https://chatgpt.com/codex/tasks/task_e_688e307766f8832d8e7b8404ee5bb3e5