### PR TITLE
Allow super admins to access Captain routes

### DIFF
--- a/app/javascript/dashboard/helper/permissionsHelper.js
+++ b/app/javascript/dashboard/helper/permissionsHelper.js
@@ -13,7 +13,13 @@ export const getCurrentAccount = ({ accounts } = {}, accountId = null) => {
 
 export const getUserPermissions = (user, accountId) => {
   const currentAccount = getCurrentAccount(user, accountId) || {};
-  return currentAccount.permissions || [];
+  const permissions = currentAccount.permissions || [];
+
+  if (user?.type === 'SuperAdmin') {
+    return [...permissions, 'super_admin'];
+  }
+
+  return permissions;
 };
 
 export const getUserRole = (user, accountId) => {

--- a/app/javascript/dashboard/routes/dashboard/captain/captain.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/captain/captain.routes.js
@@ -14,7 +14,7 @@ export const routes = [
     component: AssistantIndex,
     name: 'captain_assistants_index',
     meta: {
-      permissions: ['administrator'],
+      permissions: ['administrator', 'super_admin'],
     },
   },
   {
@@ -22,7 +22,7 @@ export const routes = [
     component: AssistantEdit,
     name: 'captain_assistants_edit',
     meta: {
-      permissions: ['administrator'],
+      permissions: ['administrator', 'super_admin'],
     },
   },
   {
@@ -32,7 +32,7 @@ export const routes = [
     component: AssistantInboxesIndex,
     name: 'captain_assistants_inboxes_index',
     meta: {
-      permissions: ['administrator'],
+      permissions: ['administrator', 'super_admin'],
     },
   },
   {
@@ -42,7 +42,7 @@ export const routes = [
     component: AssistantGuardrailsIndex,
     name: 'captain_assistants_guardrails_index',
     meta: {
-      permissions: ['administrator'],
+      permissions: ['administrator', 'super_admin'],
     },
   },
   {
@@ -52,7 +52,7 @@ export const routes = [
     component: AssistantGuidelinesIndex,
     name: 'captain_assistants_guidelines_index',
     meta: {
-      permissions: ['administrator'],
+      permissions: ['administrator', 'super_admin'],
     },
   },
   {
@@ -60,7 +60,7 @@ export const routes = [
     component: DocumentsIndex,
     name: 'captain_documents_index',
     meta: {
-      permissions: ['administrator'],
+      permissions: ['administrator', 'super_admin'],
     },
   },
   {
@@ -68,7 +68,7 @@ export const routes = [
     component: ResponsesIndex,
     name: 'captain_responses_index',
     meta: {
-      permissions: ['administrator'],
+      permissions: ['administrator', 'super_admin'],
     },
   },
 ];


### PR DESCRIPTION
## Summary
- allow super admins to pass route guards on Captain pages
- include super_admin in client side permissions list

## Testing
- `pnpm eslint app/javascript/dashboard/helper/permissionsHelper.js app/javascript/dashboard/routes/dashboard/captain/captain.routes.js`
- `pnpm test app/javascript/dashboard/helper/specs/routeHelpers.spec.js app/javascript/dashboard/routes/index.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_688e333c1a68832d8401e9335c1ea54e