### PR TITLE
chore: use pnpm in codex setup

### DIFF
--- a/setup_codex.sh
+++ b/setup_codex.sh
@@ -45,14 +45,14 @@ sudo sed -i "s/^# *requirepass .*$/requirepass redispass123/" /etc/redis/redis.c
 sudo service redis-server restart
 
 ##### 4. Ruby / Node deps #####
-# Ruby 3.4 уже есть (см. лог Codex). Установим bundler и yarn
+# Ruby 3.4 уже есть (см. лог Codex). Установим bundler и pnpm
 gem install bundler -N
-corepack enable                 # включает yarn, pnpm, etc.
-corepack prepare yarn@3.6.4 --activate
+corepack enable                 # включает pnpm и другие пакетные менеджеры
+corepack prepare pnpm@10.0.0 --activate
 
 bundle config set --local deployment 'true'
 bundle install --jobs=4 --retry=3
-yarn install --frozen-lockfile
+pnpm install --frozen-lockfile
 
 ##### 5. Подготовка БД и ассетов #####
 bundle exec rails db:prepare


### PR DESCRIPTION
## Summary
- align Codex setup script with repository's pnpm-based workflow

## Testing
- `bundle install` (missing gems)
- `pnpm install`
- `pnpm eslint` (error: module is not defined)
- `bundle exec rubocop -a` (missing rubocop)
- `pnpm test`
- `bundle exec rspec` (missing rspec)


------
https://chatgpt.com/codex/tasks/task_e_688f485ab930832d838e4efb3506768e