### PR TITLE
fix: update codex setup dependencies

### DIFF
--- a/setup_codex.sh
+++ b/setup_codex.sh
@@ -46,13 +46,15 @@ sudo service redis-server restart
 
 ##### 4. Ruby / Node deps #####
 # Ruby 3.4 уже есть (см. лог Codex). Установим bundler и pnpm
-gem install bundler -N
+# lockfile создан bundler 2.5.16, установим именно эту версию
+gem install bundler:2.5.16 -N
 corepack enable                 # включает pnpm и другие пакетные менеджеры
 corepack prepare pnpm@10.0.0 --activate
 
 bundle config set --local deployment 'true'
 bundle install --jobs=4 --retry=3
-pnpm install --frozen-lockfile
+# lockfile может не совпадать с package.json, поэтому отключаем frozen-lockfile
+pnpm install --no-frozen-lockfile
 
 ##### 5. Подготовка БД и ассетов #####
 bundle exec rails db:prepare


### PR DESCRIPTION
## Summary
- align bundler version with lockfile in Codex setup
- handle pnpm lockfile updates by removing frozen flag

## Testing
- `bash -n setup_codex.sh`
- `bundle install`
- `pnpm install --no-frozen-lockfile`


------
https://chatgpt.com/codex/tasks/task_e_688f4c55e288832da379aee40bf761c7