### PR TITLE
Fix widget SCSS imports for asset build

### DIFF
--- a/app/javascript/widget/assets/scss/woot.scss
+++ b/app/javascript/widget/assets/scss/woot.scss
@@ -1,9 +1,9 @@
-@import 'reset';
+@import 'widget/assets/scss/reset';
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 @import 'shared/assets/fonts/widget_fonts';
-@import 'views/conversation';
+@import 'widget/assets/scss/views/conversation';
 
 html,
 body {


### PR DESCRIPTION
## Summary
- fix failing widget asset build by using explicit alias paths for SCSS imports

## Testing
- `bundle exec rails assets:precompile`
- `pnpm eslint` *(fails: Cannot read config file)*
- `bundle exec rubocop`
- `pnpm test` *(fails: snapshot and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6890d5a601ec832dbbf8bcfcc52a3f49