### PR TITLE
Skip handover monitor when env missing

### DIFF
--- a/app/jobs/chatwoot/handover_monitor_job.rb
+++ b/app/jobs/chatwoot/handover_monitor_job.rb
@@ -1,7 +1,11 @@
 class Chatwoot::HandoverMonitorJob < ApplicationJob
   queue_as :scheduled_jobs
 
+  REQUIRED_ENV_VARS = %w[CHATWOOT_HOST CHATWOOT_API_KEY].freeze
+
   def perform
+    return if REQUIRED_ENV_VARS.any? { |key| ENV[key].blank? }
+
     Chatwoot::HandoverMonitorService.new.perform
   end
 end


### PR DESCRIPTION
## Summary
- avoid KeyError by skipping Chatwoot::HandoverMonitorJob if required env vars are absent

## Testing
- `bundle exec rubocop app/jobs/chatwoot/handover_monitor_job.rb` *(fails: command not found: rubocop)*
- `bin/rails runner "Chatwoot::HandoverMonitorJob.perform_now"` *(fails: Could not find rack-cors-2.0.0...)*

------
https://chatgpt.com/codex/tasks/task_e_689209713b00832d9f6e369f563a153f