### PR TITLE
fix: avoid pnpm version duplication in build assets workflow

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -30,10 +30,9 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      # pnpm 10 + Node по версии из .nvmrc
+      # pnpm (версия из package.json) + Node по версии из .nvmrc
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
           run_install: false
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- use pnpm version from package.json in build-assets workflow

## Testing
- `pnpm eslint` *(fails: module is not defined)*
- `yamllint .github/workflows/build-assets.yml`


------
https://chatgpt.com/codex/tasks/task_e_68987be6d5cc832d904a9d7a6253f60e