### PR TITLE
ci: set dummy secret key for asset build workflow

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -13,6 +13,7 @@ jobs:
       RAILS_ENV: production
       RAILS_SERVE_STATIC_FILES: "true"
       RAILS_LOG_TO_STDOUT: "1"
+      SECRET_KEY_BASE: dummy
       NODE_OPTIONS: --max-old-space-size=4096
 
     steps:


### PR DESCRIPTION
## Summary
- set SECRET_KEY_BASE in build-assets workflow to allow Rails asset tasks

## Testing
- `bundle exec rubocop` *(fails: Style/StringLiterals)*
- `pnpm eslint` *(fails: Cannot read config file: .eslintrc.js)*
- `SECRET_KEY_BASE=dummy bundle exec rails assets:precompile` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_689881770e38832db4d7c0a331e50074