### PR TITLE
ci: add explicit vite build step

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Install frontend deps
         run: pnpm install --frozen-lockfile
 
+      - name: Build Vite assets
+        run: pnpm exec vite build
+
       - name: Precompile Rails assets (Vite)
         run: |
           bundle exec rails assets:clobber
@@ -60,7 +63,8 @@ jobs:
           name: assets-${{ github.sha }}
           path: |
             build-assets.tgz
-            public/vite/**
+            public/vite/manifest.json
+            public/vite/assets/**
             public/assets/**
             public/packs/**
           if-no-files-found: warn


### PR DESCRIPTION
## Summary
- run `pnpm exec vite build` during asset build to generate manifest
- upload manifest.json with built assets

## Testing
- `pnpm eslint` *(fails: module is not defined)*
- `bundle exec rubocop` *(fails: command not found)*
- `pnpm test app/javascript/dashboard/helper/specs/editorContentHelper.spec.js`
- `bundle exec rspec spec/models/account_spec.rb:1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898e66e86f0832d83b7089a98f6c078